### PR TITLE
Pass through kwargs to pipeline calls

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,6 +43,7 @@ class SummarizerWrapper:
                     do_sample=do_sample,
                     truncation=True,
                     clean_up_tokenization_spaces=True,
+                    **kwargs,
                 )
                 return out[0]["summary_text"]
 
@@ -69,6 +70,7 @@ class SummarizerWrapper:
                     do_sample=do_sample,
                     truncation=True,
                     clean_up_tokenization_spaces=True,
+                    **kwargs,
                 )
                 partials.append(out[0]["summary_text"])
 
@@ -82,6 +84,7 @@ class SummarizerWrapper:
                     do_sample=do_sample,
                     truncation=True,
                     clean_up_tokenization_spaces=True,
+                    **kwargs,
                 )
                 return out[0]["summary_text"]
             return combined


### PR DESCRIPTION
## Summary
- Forward arbitrary kwargs when invoking the summarization pipeline to allow extra options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68be641454d4832ba521e6496e182619