### PR TITLE
docs: improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# Resumir_texto
+# Resumir texto
+
+Aplicação web simples, construída com Streamlit, para resumir textos em
+português utilizando o modelo `sshleifer/distilbart-cnn-12-6` da
+biblioteca Transformers.
+
+## Requisitos
+
+- Python 3.10 ou superior
+- Dependências Python listadas em [`requirements.txt`](requirements.txt)
+- Pacotes de sistema listados em [`packages.txt`](packages.txt)
+
+Instale os pacotes com:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Execução
+
+Para iniciar a aplicação localmente, execute:
+
+```bash
+streamlit run app.py
+```
+
+O Streamlit abrirá a interface no navegador padrão.
+
+## Licença
+
+Distribuído sob a licença [MIT](LICENSE).
+


### PR DESCRIPTION
## Summary
- expand project description and add setup instructions in README
- document requirements and licensing

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68be6430c624832b8bf02ebe7bf2baef