### PR TITLE
refactor: encapsulate streamlit app in main

### DIFF
--- a/app.py
+++ b/app.py
@@ -101,25 +101,28 @@ class SummarizerWrapper:
             return [{"summary_text": summarize_one(inputs)}]
 
 
-resumidor = carregar_resumidor()
-st.title("Resumir texto")
-texto = st.text_area("Texto de entrada")
+def main():
+    resumidor = carregar_resumidor()
+    st.title("Resumir texto")
+    texto = st.text_area("Texto de entrada")
 
-max_length = st.slider(
-    "max_length – define o número máximo de tokens (aproximadamente palavras) que a saída pode ter",
-    min_value=10,
-    max_value=500,
-    value=180,
-)
-min_length = st.slider(
-    "min_length – define o número mínimo de tokens que o resumo deve conter",
-    min_value=5,
-    max_value=max_length,
-    value=60,
-)
- main
+    max_length = st.slider(
+        "max_length – define o número máximo de tokens (aproximadamente palavras) que a saída pode ter",
+        min_value=10,
+        max_value=500,
+        value=180,
+    )
+    min_length = st.slider(
+        "min_length – define o número mínimo de tokens que o resumo deve conter",
+        min_value=5,
+        max_value=max_length,
+        value=60,
+    )
 
-if st.button("Resumir"):
-    if texto:
+    if st.button("Resumir") and texto:
         resultado = resumidor(texto, max_length=max_length, min_length=min_length)
         st.text_area("Resumo", resultado[0]["summary_text"], height=200)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- move Streamlit UI logic into a `main` function
- invoke `main` via `if __name__ == "__main__"` entry point

## Testing
- `python -m py_compile app.py`
- `streamlit run app.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf67365bc8832ba117630dd5ed81e3